### PR TITLE
Use image in compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:boron
 
 WORKDIR /usr/src/app
-VOLUME .:/usr/src/app
 
 COPY . /usr/src/app
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:boron
 
 WORKDIR /usr/src/app
+VOLUME .:/usr/src/app
 
 COPY package.json package-lock.json ./
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ FROM node:boron
 WORKDIR /usr/src/app
 VOLUME .:/usr/src/app
 
-COPY package.json package-lock.json ./
-RUN npm install
 COPY . /usr/src/app
+RUN npm install
 
 EXPOSE 3000
 

--- a/app.js
+++ b/app.js
@@ -9,7 +9,11 @@ var dotenv = require('dotenv')
 var passport = require('passport');
 var Auth0Strategy = require('passport-auth0');
 
-dotenv.load();
+// If AUTH0_DOMAIN isn't set in our environment, we probably
+// want to load everything from the .env file.
+if (!process.env.AUTH0_DOMAIN) {
+  dotenv.load();
+}
 
 var routes = require('./routes/index');
 var sampler = require('./routes/sampler');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 web:
-  build: .
+  image: docker.int.bluelabs.io/shiny-auth0:latest
+  # For local development, use the build instead of image
+  # build: .
   command: [ "npm", "start" ]
   volumes:
     - .:/usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ web:
   volumes:
     - .:/usr/src/app
   ports:
-    - "80:3000"
+    - "3000:3000"
   links:
     - sampler
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 web:
-  image: docker.int.bluelabs.io/shiny-auth0:latest
-  # For local development, use the build instead of image
-  # build: .
+  build: .
   command: [ "npm", "start" ]
   volumes:
     - .:/usr/src/app
   ports:
-    - "3000:3000"
+    - "80:3000"
   links:
     - sampler
   environment:


### PR DESCRIPTION
Fixes a few issues:

* In the old process, `node_modules/` was getting wiped out by the `COPY`. This makes running the npm install this container's problem instead of other people's problem.
* Skips loading the dotenv file if the environment variables we're looking for are present.

@vinceatbluelabs for review 